### PR TITLE
Add 'id' to widget

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -40,7 +40,8 @@ exports.main = function (options, callbacks) {
 
     // Install a widget in the addon bar to summon update URL settings
     var widget = widgets.Widget({
-        label: "Manage snippets updates",
+	id: "home-snippets-switcher",
+	label: "Manage snippets updates",
         content: 'SNIPPETS!',
         width: 100,
         panel: panel.Panel({


### PR DESCRIPTION
When compiling and running with the Addon SDK 1.0b5, on Firefox 4.0.1, the addon fails to create the widget because of a missing id attribute. This fix simply adds an id for the widget, which fixes the issue.
